### PR TITLE
Add bower.json fallback for bower deps.

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,6 +50,10 @@ Object.defineProperty(DependencyVersionChecker.prototype, 'version', {
       this._version = getVersionFromJSONFile(this._jsonPath);
     }
 
+    if (this._version === undefined && this._fallbackJsonPath) {
+      this._version = getVersionFromJSONFile(this._fallbackJsonPath);
+    }
+
     return this._version;
   }
 });
@@ -88,6 +92,7 @@ function BowerDependencyVersionChecker() {
   this._super$constructor.apply(this, arguments);
 
   this._jsonPath = path.join(this._parent._addon.project.bowerDirectory, this.name, '.bower.json');
+  this._fallbackJsonPath = path.join(this._parent._addon.project.bowerDirectory, this.name, 'bower.json');
   this._type = 'bower';
 }
 BowerDependencyVersionChecker.prototype = Object.create(DependencyVersionChecker.prototype);

--- a/tests/fixtures/bower-2/ember/.bower.json
+++ b/tests/fixtures/bower-2/ember/.bower.json
@@ -1,0 +1,21 @@
+{
+  "name": "ember",
+  "main": [
+    "./ember.debug.js",
+    "./ember-template-compiler.js"
+  ],
+  "dependencies": {
+    "jquery": ">= 1.7.0 < 2.2.0"
+  },
+  "homepage": "https://github.com/components/ember",
+  "_release": "2b5eace34b",
+  "_resolution": {
+    "type": "branch",
+    "branch": "release",
+    "commit": "2b5eace34b97f2f9e5f6ee268593f0a2f688d167"
+  },
+  "_source": "git://github.com/components/ember.git",
+  "_target": "release",
+  "_originalSource": "ember",
+  "_direct": true
+}

--- a/tests/fixtures/bower-2/ember/bower.json
+++ b/tests/fixtures/bower-2/ember/bower.json
@@ -1,0 +1,11 @@
+{
+  "name": "ember",
+  "version": "1.13.2",
+  "main": [
+    "./ember.debug.js",
+    "./ember-template-compiler.js"
+  ],
+  "dependencies": {
+    "jquery": ">= 1.7.0 < 2.2.0"
+  }
+}

--- a/tests/index.js
+++ b/tests/index.js
@@ -15,12 +15,12 @@ describe('ember-cli-version-checker', function() {
   describe('VersionChecker#for', function() {
     var addon, checker;
     beforeEach(function() {
-       addon = new FakeAddonAtVersion('0.1.15-addon-discovery-752a419d85', {
+      addon = new FakeAddonAtVersion('0.1.15-addon-discovery-752a419d85', {
         bowerDirectory: 'tests/fixtures/bower-1',
         nodeModulesPath: 'tests/fixtures/npm-1'
-       });
-       checker = new versionChecker(addon);
+      });
 
+      checker = new versionChecker(addon);
     });
 
     describe('version', function() {
@@ -28,6 +28,14 @@ describe('ember-cli-version-checker', function() {
         var thing = checker.for('ember', 'bower');
 
         assert.equal(thing.version, '1.12.1');
+      });
+
+      it('can return a fallback bower version for non-tagged releases', function() {
+        addon.project.bowerDirectory = 'tests/fixtures/bower-2';
+
+        var thing = checker.for('ember', 'bower');
+
+        assert.equal(thing.version, '1.13.2');
       });
 
       it('can return a npm version', function() {


### PR DESCRIPTION
Apparently, bower in its infinite wisdom strips `.version` out of `.bower.json` when it generates it from a branch without a tag.

This adds a fallback in that specific case, to allow grabbing the version from the "real" `bower.json` which may have a version specified.