### PR TITLE
Support beta/canary version number format

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,14 +54,12 @@ Object.defineProperty(DependencyVersionChecker.prototype, 'version', {
       this._version = getVersionFromJSONFile(this._fallbackJsonPath);
     }
 
-    if (this._version) {
-      return this._version.split('-')[0];
-    }
+    return this._version;
   }
 });
 
 DependencyVersionChecker.prototype.isAbove = function isAbove(compareVersion) {
-  return semver.satisfies(this.version, '>' + compareVersion);
+  return semver.gt(this.version, compareVersion);
 }
 
 var semverMethods = ['gt', 'lt', 'satisfies'];

--- a/index.js
+++ b/index.js
@@ -54,7 +54,9 @@ Object.defineProperty(DependencyVersionChecker.prototype, 'version', {
       this._version = getVersionFromJSONFile(this._fallbackJsonPath);
     }
 
-    return this._version;
+    if (this._version) {
+      return this._version.split('-')[0];
+    }
   }
 });
 

--- a/tests/fixtures/bower-3/ember/.bower.json
+++ b/tests/fixtures/bower-3/ember/.bower.json
@@ -1,0 +1,21 @@
+{
+  "name": "ember",
+  "main": [
+    "./ember.debug.js",
+    "./ember-template-compiler.js"
+  ],
+  "dependencies": {
+    "jquery": ">= 1.7.0 < 2.2.0"
+  },
+  "homepage": "https://github.com/components/ember",
+  "_release": "2b5eace34b",
+  "_resolution": {
+    "type": "branch",
+    "branch": "release",
+    "commit": "2b5eace34b97f2f9e5f6ee268593f0a2f688d167"
+  },
+  "_source": "git://github.com/components/ember.git",
+  "_target": "release",
+  "_originalSource": "ember",
+  "_direct": true
+}

--- a/tests/fixtures/bower-3/ember/bower.json
+++ b/tests/fixtures/bower-3/ember/bower.json
@@ -1,0 +1,11 @@
+{
+  "name": "ember",
+  "version": "2.3.0-beta.2+41030996",
+  "main": [
+    "./ember.debug.js",
+    "./ember-template-compiler.js"
+  ],
+  "dependencies": {
+    "jquery": ">= 1.7.0 < 2.2.0"
+  }
+}

--- a/tests/index.js
+++ b/tests/index.js
@@ -38,14 +38,6 @@ describe('ember-cli-version-checker', function() {
         assert.equal(thing.version, '1.13.2');
       });
 
-      it('can handle beta releases', function() {
-        addon.project.bowerDirectory = 'tests/fixtures/bower-3';
-
-        var thing = checker.for('ember', 'bower');
-
-        assert.equal(thing.version, '2.3.0');
-      });
-
       it('can return a npm version', function() {
         var thing = checker.for('ember', 'npm');
 
@@ -90,6 +82,22 @@ describe('ember-cli-version-checker', function() {
         var thing = checker.for('ember', 'npm');
 
         assert.equal(thing.isAbove('99.0.0'), false);
+      });
+
+      it('returns true on beta releases if version is above the specified range', function() {
+        addon.project.bowerDirectory = 'tests/fixtures/bower-3';
+
+        var thing = checker.for('ember', 'bower');
+
+        assert.equal(thing.isAbove('2.2.0'), true);
+      });
+
+      it('returns false on beta releases if version is below the specified range', function() {
+        addon.project.bowerDirectory = 'tests/fixtures/bower-3';
+
+        var thing = checker.for('ember', 'bower');
+
+        assert.equal(thing.isAbove('2.3.0'), false);
       });
     });
 

--- a/tests/index.js
+++ b/tests/index.js
@@ -38,6 +38,14 @@ describe('ember-cli-version-checker', function() {
         assert.equal(thing.version, '1.13.2');
       });
 
+      it('can handle beta releases', function() {
+        addon.project.bowerDirectory = 'tests/fixtures/bower-3';
+
+        var thing = checker.for('ember', 'bower');
+
+        assert.equal(thing.version, '2.3.0');
+      });
+
       it('can return a npm version', function() {
         var thing = checker.for('ember', 'npm');
 


### PR DESCRIPTION
We should support beta and canary version formats in the form of `2.3.0-beta.2+41030996`, since tools like `ember try:testall` will attempt to pull down prerelease versions that don't (yet) have strictly semver compatible numbers.