### PR TITLE
Fix bower dependency path when in child directory

### DIFF
--- a/index.js
+++ b/index.js
@@ -91,8 +91,11 @@ DependencyVersionChecker.prototype._super$constructor = DependencyVersionChecker
 function BowerDependencyVersionChecker() {
   this._super$constructor.apply(this, arguments);
 
-  this._jsonPath = path.join(this._parent._addon.project.bowerDirectory, this.name, '.bower.json');
-  this._fallbackJsonPath = path.join(this._parent._addon.project.bowerDirectory, this.name, 'bower.json');
+  var project = this._parent._addon.project;
+  var bowerDependencyPath = path.join(project.root, project.bowerDirectory, this.name);
+
+  this._jsonPath = path.join(bowerDependencyPath, '.bower.json');
+  this._fallbackJsonPath = path.join(bowerDependencyPath, 'bower.json');
   this._type = 'bower';
 }
 BowerDependencyVersionChecker.prototype = Object.create(DependencyVersionChecker.prototype);

--- a/tests/index.js
+++ b/tests/index.js
@@ -16,7 +16,8 @@ describe('ember-cli-version-checker', function() {
     var addon, checker;
     beforeEach(function() {
       addon = new FakeAddonAtVersion('0.1.15-addon-discovery-752a419d85', {
-        bowerDirectory: 'tests/fixtures/bower-1',
+        root: 'tests/fixtures',
+        bowerDirectory: 'bower-1',
         nodeModulesPath: 'tests/fixtures/npm-1'
       });
 
@@ -31,7 +32,7 @@ describe('ember-cli-version-checker', function() {
       });
 
       it('can return a fallback bower version for non-tagged releases', function() {
-        addon.project.bowerDirectory = 'tests/fixtures/bower-2';
+        addon.project.bowerDirectory = 'bower-2';
 
         var thing = checker.for('ember', 'bower');
 
@@ -85,7 +86,7 @@ describe('ember-cli-version-checker', function() {
       });
 
       it('returns true on beta releases if version is above the specified range', function() {
-        addon.project.bowerDirectory = 'tests/fixtures/bower-3';
+        addon.project.bowerDirectory = 'bower-3';
 
         var thing = checker.for('ember', 'bower');
 
@@ -93,7 +94,7 @@ describe('ember-cli-version-checker', function() {
       });
 
       it('returns false on beta releases if version is below the specified range', function() {
-        addon.project.bowerDirectory = 'tests/fixtures/bower-3';
+        addon.project.bowerDirectory = 'bower-3';
 
         var thing = checker.for('ember', 'bower');
 


### PR DESCRIPTION
I found this bug while investigating https://github.com/emberjs/data/issues/4096

Basically, when you're in a child directory of your app, such as `your-app/app/`, the dependency checks for bower components fail because they cannot find the version.

This is because the version checker is using `project.bowerDirectory` to build the path to the dependency. Since `project.bowerDirectory` defaults to the name "bower_components" and not the actual path, this doesn't work unless you're inside your app's root directory when the dependency check is run.

~~I'm not sure how to write a test that covers this but I promise it works~~ :smiling_imp: 