### PR TITLE
Include only necessary files in the npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
     "lodash": "^3.9.3",
     "mocha": "^2.1.0"
   },
+  "files": [
+    "index.js"
+  ],
   "directories": {
     "test": "tests"
   },


### PR DESCRIPTION
This removes `/tests`, which should curb the 51 files reported at https://github.com/ember-cli/ember-welcome-page/issues/33.