### PR TITLE
Add #forEmber helper method to get ember version from bower or npm

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,6 +42,16 @@ VersionChecker.prototype.for = function(name, type) {
   }
 };
 
+VersionChecker.prototype.forEmber = function() {
+  var emberVersionChecker = this.for('ember-source', 'npm');
+
+  if (emberVersionChecker.version) {
+    return emberVersionChecker;
+  }
+
+  return this.for('ember', 'bower');
+};
+
 /**
  * DependencyVersionChecker
  */

--- a/tests/fixtures/npm-3/ember-source/package.json
+++ b/tests/fixtures/npm-3/ember-source/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "ember-source",
+  "version": "2.10.0",
+  "description": "Ember Application Framework",
+  "keywords": [
+    "ember"
+  ],
+  "main": "./ember.debug.js",
+  "dependencies": {
+    "jquery": ">=1.7.0 < 2.2.0"
+  }
+}

--- a/tests/index.js
+++ b/tests/index.js
@@ -12,6 +12,32 @@ describe('ember-cli-version-checker', function() {
     }, projectProperties);
   }
 
+  describe('VersionChecker#forEmber', function() {
+    var addon, checker;
+    beforeEach(function() {
+      addon = new FakeAddonAtVersion('1.0.0', {
+        root: 'tests/fixtures',
+        bowerDirectory: 'bower-2',
+        nodeModulesPath: 'tests/fixtures/npm-3'
+      });
+
+      checker = new VersionChecker(addon);
+    });
+
+    describe('version', function() {
+      it('returns the bower version if ember-source is not present in npm', function() {
+        addon.project.nodeModulesPath = 'tests/fixtures/npm-1';
+        var thing = checker.forEmber();
+        assert.equal(thing.version, '1.13.2');
+      });
+
+      it('returns the ember-source version before looking for ember in bower', function() {
+        var thing = checker.forEmber();
+        assert.equal(thing.version, '2.10.0');
+      });
+    });
+  });
+
   describe('VersionChecker#for', function() {
     var addon, checker;
     beforeEach(function() {


### PR DESCRIPTION
This adds a method `forEmber` that will look for `ember` in bower, if it does not find it, this will look for `ember-source` in NPM.

cc/ @rwjblue
