### PR TITLE
All operations like `gt`, `lt`, `isAbove`, etc must return false if the dependency is not present

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,22 @@
+{
+    // Use IntelliSense to learn about possible Node.js debug attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Launch Program",
+            "program": "${workspaceRoot}/node_modules/mocha/bin/_mocha",
+            "args": ["tests", "--debug"],
+            "cwd": "${workspaceRoot}"
+        },
+        {
+            "type": "node",
+            "request": "attach",
+            "name": "Attach to Process",
+            "port": 5858
+        }
+    ]
+}

--- a/index.js
+++ b/index.js
@@ -59,12 +59,18 @@ Object.defineProperty(DependencyVersionChecker.prototype, 'version', {
 });
 
 DependencyVersionChecker.prototype.isAbove = function isAbove(compareVersion) {
+  if (!this.version) {
+    return false;
+  }
   return semver.gt(this.version, compareVersion);
 }
 
 var semverMethods = ['gt', 'lt', 'satisfies'];
 semverMethods.forEach(function(method) {
   DependencyVersionChecker.prototype[method] = function(range) {
+    if (!this.version) {
+      return false;
+    }
     return semver[method](this.version, range);
   };
 });
@@ -91,7 +97,8 @@ DependencyVersionChecker.prototype._super$constructor = DependencyVersionChecker
 function BowerDependencyVersionChecker() {
   this._super$constructor.apply(this, arguments);
 
-  var project = this._parent._addon.project;
+  var addon = this._parent._addon;
+  var project = addon.project;
   var bowerDependencyPath = path.join(project.root, project.bowerDirectory, this.name);
 
   this._jsonPath = path.join(bowerDependencyPath, '.bower.json');
@@ -103,9 +110,11 @@ BowerDependencyVersionChecker.prototype = Object.create(DependencyVersionChecker
 
 function NPMDependencyVersionChecker() {
   this._super$constructor.apply(this, arguments);
-  var project = this._parent._addon.project;
+  var addon = this._parent._addon;
+  var project = addon.project;
   var nodeModulesPath = project.nodeModulesPath || path.join(project.root, 'node_modules')
-  this._jsonPath = path.join(nodeModulesPath, this.name, 'package.json');
+  var npmDependencyPath = path.join(nodeModulesPath, this.name);
+  this._jsonPath = path.join(npmDependencyPath, 'package.json');
   this._type = 'npm';
 }
 NPMDependencyVersionChecker.prototype = Object.create(DependencyVersionChecker.prototype);

--- a/tests/fixtures/bower-4/.gitkeep
+++ b/tests/fixtures/bower-4/.gitkeep
@@ -1,0 +1,1 @@
+This folder is empty on purpose

--- a/tests/fixtures/npm-2/.gitkeep
+++ b/tests/fixtures/npm-2/.gitkeep
@@ -1,0 +1,1 @@
+This folder is empty on purpose

--- a/tests/index.js
+++ b/tests/index.js
@@ -70,6 +70,19 @@ describe('ember-cli-version-checker', function() {
 
         assert.equal(thing.satisfies('>= 99.0.0'), false);
       });
+
+      it('returns false if the dependency does not exist', function() {
+        addon = new FakeAddonAtVersion('0.1.15-addon-discovery-752a419d85', {
+          root: 'tests/fixtures',
+          bowerDirectory: 'bower-2',
+          nodeModulesPath: 'tests/fixtures/npm-2'
+        });
+
+        checker = new versionChecker(addon);
+        var thing = checker.for('ember-source', 'npm');
+
+        assert.equal(thing.satisfies('>= 2.9'), false);
+      });
     });
 
     describe('isAbove', function() {
@@ -100,6 +113,19 @@ describe('ember-cli-version-checker', function() {
 
         assert.equal(thing.isAbove('2.3.0'), false);
       });
+
+      it('returns false if the dependency does not exist', function() {
+        addon = new FakeAddonAtVersion('0.1.15-addon-discovery-752a419d85', {
+          root: 'tests/fixtures',
+          bowerDirectory: 'bower-2',
+          nodeModulesPath: 'tests/fixtures/npm-2'
+        });
+
+        checker = new versionChecker(addon);
+        var thing = checker.for('ember-source', 'npm');
+
+        assert.equal(thing.isAbove('2.9.0'), false);
+      });
     });
 
     describe('gt', function() {
@@ -114,6 +140,19 @@ describe('ember-cli-version-checker', function() {
 
         assert.equal(thing.gt('99.0.0'), false);
       });
+
+      it('returns false if the dependency does not exist', function() {
+        addon = new FakeAddonAtVersion('0.1.15-addon-discovery-752a419d85', {
+          root: 'tests/fixtures',
+          bowerDirectory: 'bower-2',
+          nodeModulesPath: 'tests/fixtures/npm-2'
+        });
+
+        checker = new versionChecker(addon);
+        var thing = checker.for('ember-source', 'npm');
+
+        assert.equal(thing.gt('2.9.0'), false);
+      });
     });
 
     describe('lt', function() {
@@ -127,6 +166,19 @@ describe('ember-cli-version-checker', function() {
         var thing = checker.for('ember', 'npm');
 
         assert.equal(thing.lt('99.0.0'), true);
+      });
+
+      it('returns false if the dependency does not exist', function() {
+        addon = new FakeAddonAtVersion('0.1.15-addon-discovery-752a419d85', {
+          root: 'tests/fixtures',
+          bowerDirectory: 'bower-2',
+          nodeModulesPath: 'tests/fixtures/npm-2'
+        });
+
+        checker = new versionChecker(addon);
+        var thing = checker.for('ember-source', 'npm');
+
+        assert.equal(thing.lt('2.9.0'), false);
       });
     });
 


### PR DESCRIPTION
They return false instead of throwing. If the users wants the operation to throw,
they can use `assert*` methods